### PR TITLE
disable ripple

### DIFF
--- a/modules/pagesModule/PagesDetail/Layout/DragMeEdit.js
+++ b/modules/pagesModule/PagesDetail/Layout/DragMeEdit.js
@@ -204,7 +204,8 @@ const DragMe = (props) => {
             onClick={() => {
               deleteItem(contents, index);
             }}
-            size='small'>
+            size='small'
+            disableRipple>
             <DeleteIcon />
           </IconButton>
           <span>{contents.key}</span>{' '}

--- a/modules/pagesModule/PagesDetail/Layout/EditLayout.js
+++ b/modules/pagesModule/PagesDetail/Layout/EditLayout.js
@@ -159,20 +159,22 @@ const EditLayout = ({open, setOpen, titleKey, pageKey}) => {
             edge='start'
             color='inherit'
             onClick={handleClose}
-            aria-label='close'>
+            aria-label='close'
+            disableRipple>
             <ArrowBackIcon />
           </IconButton>
           <Typography variant='h6' className={classes.title}>
             {titleKey} {' / Edit'}
           </Typography>
-          <Button autoFocus={true} color='inherit' onClick={handleClose}>
+          <Button autoFocus={true} color='inherit' onClick={handleClose} disableRipple>
             Cancel
           </Button>
           <Button
             style={{backgroundColor: orange[500], color: 'white', marginLeft: 15}}
             classes={classes.button}
             autoFocus={true}
-            onClick={handleRootSave}>
+            onClick={handleRootSave}
+            disableRipple>
             Apply Changes
           </Button>
         </Toolbar>

--- a/modules/pagesModule/PagesDetail/Layout/LayoutEditView.js
+++ b/modules/pagesModule/PagesDetail/Layout/LayoutEditView.js
@@ -485,7 +485,7 @@ const LayoutEditView = forwardRef((props, ref) => {
                   onChange={(e) => setQuery(e.target.value)}
                   onKeyDown={handleEnter}
                 />
-                <IconButton className={classes.iconButton} aria-label='search'>
+                <IconButton className={classes.iconButton} aria-label='search' disableRipple>
                   <SearchIcon />
                 </IconButton>
                 {/*<Divider className={classes.divider} orientation='vertical' />*/}
@@ -588,7 +588,8 @@ const LayoutEditView = forwardRef((props, ref) => {
                     <div className={classes.floatingButtons}>
                       <Fab
                         onClick={() => deleteRow('header', k)}
-                        className={clsx(classes.tinyBtn)}>
+                        className={clsx(classes.tinyBtn)}
+                        disableRipple>
                         <Delete />
                       </Fab>
                     </div>
@@ -598,7 +599,8 @@ const LayoutEditView = forwardRef((props, ref) => {
               <div className={classes.divDragWrap}>
                 <Fab
                   onClick={() => handleAddNewRow('header')}
-                  className={clsx(classes.tinyBtn)}>
+                  className={clsx(classes.tinyBtn)}
+                  disableRipple>
                   <Add />
                 </Fab>
               </div>
@@ -634,7 +636,8 @@ const LayoutEditView = forwardRef((props, ref) => {
                     <div className={classes.floatingButtons}>
                       <Fab
                         onClick={() => deleteRow('body', k)}
-                        className={clsx(classes.tinyBtn)}>
+                        className={clsx(classes.tinyBtn)}
+                        disableRipple>
                         <Delete />
                       </Fab>
                     </div>
@@ -644,7 +647,8 @@ const LayoutEditView = forwardRef((props, ref) => {
               <div className={classes.divDragWrap}>
                 <Fab
                   onClick={() => handleAddNewRow('body')}
-                  className={clsx(classes.tinyBtn)}>
+                  className={clsx(classes.tinyBtn)}
+                  disableRipple>
                   <Add />
                 </Fab>
               </div>
@@ -680,7 +684,8 @@ const LayoutEditView = forwardRef((props, ref) => {
                     <div className={classes.floatingButtons}>
                       <Fab
                         onClick={() => deleteRow('footer', k)}
-                        className={clsx(classes.tinyBtn)}>
+                        className={clsx(classes.tinyBtn)}
+                        disableRipple>
                         <Delete />
                       </Fab>
                     </div>
@@ -690,7 +695,8 @@ const LayoutEditView = forwardRef((props, ref) => {
               <div className={classes.divDragWrap}>
                 <Fab
                   onClick={() => handleAddNewRow('footer')}
-                  className={clsx(classes.tinyBtn)}>
+                  className={clsx(classes.tinyBtn)}
+                  disableRipple>
                   <Add />
                 </Fab>
               </div>

--- a/modules/pagesModule/PagesDetail/Layout/LayoutSettings.js
+++ b/modules/pagesModule/PagesDetail/Layout/LayoutSettings.js
@@ -177,7 +177,7 @@ const LayoutSettings = ({settingsObj}) => {
                 expanded={expanded === 'panel1'}
                 style={{borderBottom: '1px solid #c3c3c3'}}
                 onChange={handleChange('panel1')}>
-                <AccordionSummary aria-controls='panel1d-content' id='panel1d-header'>
+                <AccordionSummary aria-controls='panel1d-content' id='panel1d-header' disableRipple>
                     <Typography>General Settings</Typography>
                 </AccordionSummary>
                 <AccordionDetails className={classes.accordianDetails}>
@@ -205,7 +205,7 @@ const LayoutSettings = ({settingsObj}) => {
                 // expanded={expanded === 'panel2'}
                 expanded={true}
                 onChange={handleChange('panel2')}>
-                <AccordionSummary aria-controls='panel2d-content' id='panel2d-header'>
+                <AccordionSummary aria-controls='panel2d-content' id='panel2d-header' disableRipple>
                     <Typography>Widget Props</Typography>
                 </AccordionSummary>
                 <AccordionDetails>

--- a/modules/pagesModule/PagesDetail/Layout/NewCellModal.js
+++ b/modules/pagesModule/PagesDetail/Layout/NewCellModal.js
@@ -94,7 +94,7 @@ const NewCellModal = (props) => {
             style={{display: 'flex', flexDirection: 'column'}}>
             <Box>
               <Card style={{maxWidth: '100%'}}>
-                <CardActionArea>
+                <CardActionArea disableRipple>
                   <CardMedia
                     component='img'
                     alt='Material UI ref'
@@ -127,7 +127,8 @@ const NewCellModal = (props) => {
                         'https://material-ui.com/customization/breakpoints/',
                         '_blank',
                       );
-                    }}>
+                    }}
+                    disableRipple>
                     Learn More
                   </Button>
                 </CardActions>
@@ -151,7 +152,7 @@ const NewCellModal = (props) => {
         </Grid>
       </DialogContent>
       <DialogActions>
-        <Button autoFocus={true} onClick={handleCloseNewCell} color='primary'>
+        <Button autoFocus={true} onClick={handleCloseNewCell} color='primary' disableRipple>
           Cancel
         </Button>
         <Button
@@ -159,7 +160,8 @@ const NewCellModal = (props) => {
           onClick={() => {
             handleSaveNewCell(newCellRowIndex, section, layoutWidth);
           }}
-          color='primary'>
+          color='primary'
+          disableRipple>
           Save changes
         </Button>
       </DialogActions>

--- a/modules/pagesModule/PagesDetail/Layout/TemplateProps.js
+++ b/modules/pagesModule/PagesDetail/Layout/TemplateProps.js
@@ -76,7 +76,7 @@ const NewProp = ({classes}) => {
             justifyContent: 'flex-start',
             alignItems: 'center',
           }}>
-          <IconButton onClick={() => true} disabled={true}>
+          <IconButton onClick={() => true} disabled={true} disableRipple>
             <Icon
               color='secondary'
               className={classes.Icon}
@@ -173,7 +173,8 @@ export default function TemplateProps({cellProps, disabled}) {
             <AccordionSummary
               expandIcon={<ExpandMoreIcon />}
               aria-controls='panel1bh-content'
-              id='panel1bh-header'>
+              id='panel1bh-header'
+              disableRipple>
               <span style={{fontWeight: 500}}>{propKey}</span>
             </AccordionSummary>
             <AccordionDetails classes={{root: classes.accordianDetails}}>
@@ -240,12 +241,13 @@ export default function TemplateProps({cellProps, disabled}) {
                     classes={{
                       root: classes.inputAdornmentRoot, // Create a class in `makeStyles` to handle the style overrides
                     }}>
-                    <IconButton onClick={() => handleSave(propKey)} edge='end'>
+                    <IconButton onClick={() => handleSave(propKey)} edge='end' disableRipple>
                       <CheckCircleIcon style={{color: 'green'}} />
                     </IconButton>
                     <IconButton
                       onClick={() => handleCancel(propKey)}
-                      edge='end'>
+                      edge='end'
+                      disableRipple>
                       <CancelIcon style={{color: 'red'}} />
                     </IconButton>
                   </InputAdornment>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Disables Material-UI ripple effects across layout editor buttons, icons, fabs, accordions, and card actions.
> 
> - **Layout Editor UI**
>   - Add `disableRipple` to navigation buttons (`ArrowBack`, `Cancel`, `Apply Changes`) in `EditLayout.js`.
>   - Add `disableRipple` to delete `IconButton` in `DragMeEdit.js`.
>   - Add `disableRipple` to search `IconButton` and multiple `Fab` add/delete controls in `LayoutEditView.js`.
>   - Add `disableRipple` to `AccordionSummary` sections in `LayoutSettings.js`.
>   - Add `disableRipple` to `CardActionArea` and dialog `Button`s in `NewCellModal.js`.
>   - Add `disableRipple` to `AccordionSummary` and action `IconButton`s in `TemplateProps.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 371abce92387f0a8ddd4d9b965d576efa7044f0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Disabled ripple animations on interactive buttons and controls throughout the layout editor for a cleaner, more refined interaction experience when editing page layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->