### PR TITLE
Restyle AI widget generator and fix blank previews

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,1 +1,2 @@
 NEXT_PUBLIC_SERVICE_URL=http://localhost:10001
+NEXT_PUBLIC_AI_SERVICE_URL=http://localhost:5001

--- a/modules/aiBuilder/config.js
+++ b/modules/aiBuilder/config.js
@@ -5,88 +5,126 @@ import * as MaterialStyles from '@material-ui/core/styles';
 import * as MaterialPickers from '@material-ui/pickers';
 import * as EmotionReact from '@emotion/react';
 import * as EmotionStyled from '@emotion/styled';
+import {Formik, Form, Field, useField} from 'formik';
+import * as Yup from 'yup';
+import {SLING_ORANGE, SLING_WIDGET_THEME} from './slingTheme';
 
-// Custom theme configuration for Claude-generated components
-const claudeTheme = {
-  palette: {
-    primary: {
-      main: '#2196F3',
-      contrastText: '#fff',
-    },
-    secondary: {
-      main: '#1976D2',
-    },
-    background: {
-      default: '#F8F9FA',
-      paper: '#FFFFFF',
-    },
-    text: {
-      primary: '#212121',
-      secondary: '#757575',
-    },
-  },
-  typography: {
-    fontFamily: 'Inter, system-ui, sans-serif',
-    h1: { fontSize: 24, fontWeight: 600 },
-    h2: { fontSize: 20, fontWeight: 600 },
-    h3: { fontSize: 18, fontWeight: 500 },
-    body1: { fontSize: 16 },
-    body2: { fontSize: 14 },
-    button: {
-      textTransform: 'none',
-      fontWeight: 500,
-    },
-  },
-  shape: {
-    borderRadius: 8,
-  },
-  components: {
+const DEFAULT_CORE_COMPONENTS = [
+  'AppBar',
+  'Avatar',
+  'Box',
+  'Button',
+  'Card',
+  'CardActions',
+  'CardContent',
+  'CardMedia',
+  'Checkbox',
+  'Chip',
+  'CircularProgress',
+  'Container',
+  'Divider',
+  'FormControl',
+  'FormControlLabel',
+  'FormHelperText',
+  'Grid',
+  'Icon',
+  'IconButton',
+  'InputAdornment',
+  'InputLabel',
+  'LinearProgress',
+  'Link',
+  'List',
+  'ListItem',
+  'ListItemIcon',
+  'ListItemText',
+  'MenuItem',
+  'Paper',
+  'Select',
+  'Switch',
+  'Tab',
+  'Table',
+  'TableBody',
+  'TableCell',
+  'TableContainer',
+  'TableHead',
+  'TableRow',
+  'Tabs',
+  'TextField',
+  'Toolbar',
+  'Tooltip',
+  'Typography',
+];
+
+const DEFAULT_ICONS = [
+  'Add',
+  'ArrowForward',
+  'AttachMoney',
+  'Check',
+  'CheckCircle',
+  'Close',
+  'Delete',
+  'Edit',
+  'Email',
+  'ExpandLess',
+  'ExpandMore',
+  'Favorite',
+  'Home',
+  'Info',
+  'Lock',
+  'Person',
+  'Phone',
+  'Search',
+  'Settings',
+  'ShoppingCart',
+  'Star',
+  'Visibility',
+  'VisibilityOff',
+  'Warning',
+];
+
+const slingPreviewTheme = {
+  ...SLING_WIDGET_THEME,
+  overrides: {
     MuiButton: {
-      styleOverrides: {
-        root: {
-          borderRadius: 8,
-          padding: '8px 16px',
-          fontWeight: 500,
-        },
-        contained: {
-          boxShadow: 'none',
-          '&:hover': {
-            boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
-          },
-        },
-        text: {
-          color: '#2196F3',
+      root: {
+        borderRadius: 6,
+        padding: '8px 16px',
+        fontWeight: 500,
+        textTransform: 'none',
+      },
+      containedPrimary: {
+        backgroundColor: SLING_ORANGE,
+        '&:hover': {
+          backgroundColor: '#f57c00',
         },
       },
+      textPrimary: {
+        color: SLING_ORANGE,
+      },
     },
-    MuiPaper: {
-      styleOverrides: {
-        root: {
-          backgroundColor: '#fff',
-          borderRadius: 8,
+    MuiTextField: {
+      root: {
+        backgroundColor: '#fff',
+      },
+    },
+    MuiOutlinedInput: {
+      root: {
+        backgroundColor: '#fff',
+        '&$focused $notchedOutline': {
+          borderColor: SLING_ORANGE,
         },
       },
     },
     MuiAppBar: {
-      styleOverrides: {
-        root: {
-          backgroundColor: '#2196F3',
-        },
-      },
-    },
-    MuiCard: {
-      styleOverrides: {
-        root: {
-          borderRadius: 12,
-          boxShadow: '0 2px 8px rgba(0,0,0,0.05)',
-          border: '1px solid rgba(0,0,0,0.08)',
-        },
+      colorPrimary: {
+        backgroundColor: SLING_ORANGE,
       },
     },
     MuiCheckbox: {
-      styleOverrides: {
-        root: {
-          color: '#757575',
+      colorPrimary: {
+        color: SLING_ORANGE,
+        '&$checked': {
+          color: SLING_ORANGE,
         },
       },
     },
@@ -240,29 +278,23 @@ export const createScope = ({
 
   const mergedTheme = themeOverrides
     ? {
-        ...claudeTheme,
+        ...slingPreviewTheme,
         ...themeOverrides,
         palette: {
-          ...claudeTheme.palette,
+          ...slingPreviewTheme.palette,
           ...(themeOverrides.palette || {}),
         },
       }
-    : claudeTheme;
+    : slingPreviewTheme;
 
   // Create theme instance
   const theme = MaterialStyles.createTheme(mergedTheme);
 
-  // Create a wrapper component that applies the theme
-  const ThemedComponent = ({ children }) => {
-    return React.createElement(
-      MaterialUI.StyledEngineProvider,
-      { injectFirst: true },
-      React.createElement(
-        libraryMap['@material-ui/core'].ThemeProvider,
-        { theme },
-        children
-      )
-    );
+  const ThemeProvider =
+    libraryMap['@material-ui/core'].ThemeProvider || MaterialStyles.ThemeProvider;
+
+  const ThemedComponent = ({children}) => {
+    return React.createElement(ThemeProvider, {theme}, children);
   };
 
   // Create base scope
@@ -277,33 +309,23 @@ export const createScope = ({
     makeStyles,
   };
 
-  // Process dependencies and add components to scope
-  Object.entries(dependencies).forEach(([library, components]) => {
+  const addToScope = (library, comp) => {
+    if (scope[comp]) return;
+    const component = findComponent(libraryMap, library, comp);
+    if (component) {
+      scope[comp] = component;
+      return;
+    }
+    const fallback = getFallbackComponent(libraryMap, library, comp);
+    scope[comp] = fallback || createPlaceholder(React, comp);
+  };
+
+  DEFAULT_CORE_COMPONENTS.forEach((comp) => addToScope('@material-ui/core', comp));
+  DEFAULT_ICONS.forEach((comp) => addToScope('@material-ui/icons', comp));
+
+  Object.entries(dependencies || {}).forEach(([library, components]) => {
     try {
-      components.forEach((comp) => {
-        // Try to find the component
-        const component = findComponent(libraryMap, library, comp);
-        
-        if (component) {
-          scope[comp] = component;
-        } else {
-          // Try to get a fallback
-          const fallback = getFallbackComponent(libraryMap, library, comp);
-          
-          if (fallback) {
-            console.warn(
-              `Component ${comp} not found in ${library}, using fallback:`,
-              fallback.displayName || fallback.name || 'Unknown'
-            );
-            scope[comp] = fallback;
-          } else {
-            console.error(
-              `Component ${comp} not found in ${library} and no fallback available`
-            );
-            scope[comp] = createPlaceholder(React, comp);
-          }
-        }
-      });
+      (components || []).forEach((comp) => addToScope(library, comp));
     } catch (error) {
       console.error(`Error processing library ${library}:`, error);
     }
@@ -311,6 +333,11 @@ export const createScope = ({
 
   return {
     ...scope,
+    Formik,
+    Form,
+    Field,
+    useField,
+    Yup,
     ThemedComponent,
     findComponent: (library, componentName) => findComponent(libraryMap, library, componentName),
     getFallbackComponent: (library, componentName) => getFallbackComponent(libraryMap, library, componentName),

--- a/modules/aiBuilder/slingTheme.js
+++ b/modules/aiBuilder/slingTheme.js
@@ -1,0 +1,36 @@
+// Brand tokens from sling.biz / slingEarly — orange, not default MUI blue.
+export const SLING_ORANGE = '#ff9800';
+export const SLING_ORANGE_SOFT = '#ff9387';
+export const SLING_CREAM = '#fff8f0';
+export const SLING_INK = '#212121';
+
+export const SLING_WIDGET_THEME = {
+  palette: {
+    primary: {
+      main: SLING_ORANGE,
+      contrastText: '#fff',
+    },
+    secondary: {
+      main: SLING_ORANGE_SOFT,
+      contrastText: '#fff',
+    },
+    background: {
+      default: SLING_CREAM,
+      paper: '#FFFFFF',
+    },
+    text: {
+      primary: SLING_INK,
+      secondary: '#666666',
+    },
+  },
+  typography: {
+    fontFamily: 'Open Sans, system-ui, sans-serif',
+    button: {
+      textTransform: 'none',
+      fontWeight: 500,
+    },
+  },
+  shape: {
+    borderRadius: 6,
+  },
+};

--- a/modules/widgetsModule/AiGenerateWidget/index.js
+++ b/modules/widgetsModule/AiGenerateWidget/index.js
@@ -7,69 +7,169 @@ import {
   Button,
   Typography,
   Paper,
-  IconButton,
   Icon,
-  LinearProgress,
+  Chip,
 } from '@material-ui/core';
 import {Fonts} from '../../../shared/constants/AppEnums';
 import AppsHeader from '../../../@sling/core/AppsContainer/AppsHeader';
 import {useDispatch} from 'react-redux';
-import {saveGeneratedWidget, submitForReview} from '../../../redux/actions/Widgets';
+import {
+  generateWidget,
+  saveGeneratedWidget,
+  submitForReview,
+} from '../../../redux/actions/Widgets';
 import SandboxedPreview from '../../aiBuilder/components/SandboxedPreview';
-import Chip from '@material-ui/core/Chip';
 import {useRouter} from 'next/router';
-import {AI_SERVICE_URL} from '../../../shared/constants/Services';
+import {AI_SERVICE_URL, SERVICE_URL} from '../../../shared/constants/Services';
+import ApiAuth from '../../../@sling/services/ApiAuthConfig';
+import {SLING_ORANGE, SLING_CREAM, SLING_WIDGET_THEME} from '../../aiBuilder/slingTheme';
+
+const STARTER_PROMPTS = [
+  'Login form with email, password, and remember-me',
+  'Three-tier pricing table',
+  'Hero banner with headline and CTA',
+  'Testimonial cards',
+  'FAQ accordion',
+  'Newsletter signup',
+];
 
 const useStyles = makeStyles((theme) => ({
   root: {
     height: '100%',
     display: 'flex',
     flexDirection: 'column',
+    backgroundColor: '#fff',
   },
   content: {
     flex: 1,
-    padding: 20,
+    padding: '28px 32px 40px',
     overflow: 'auto',
+    background: `linear-gradient(180deg, ${SLING_CREAM} 0%, #ffffff 220px)`,
   },
-  promptSection: {
+  hero: {
+    maxWidth: 760,
+    margin: '0 auto 8px',
+    textAlign: 'center',
+  },
+  eyebrow: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 6,
+    color: SLING_ORANGE,
+    fontWeight: 600,
+    fontSize: 12,
+    letterSpacing: '0.08em',
+    textTransform: 'uppercase',
+    marginBottom: 8,
+  },
+  title: {
+    fontWeight: 700,
+    fontSize: 28,
+    lineHeight: 1.25,
+    color: '#1a1a1a',
+    marginBottom: 8,
+  },
+  subtitle: {
+    color: theme.palette.text.secondary,
+    fontSize: 15,
     marginBottom: 24,
+  },
+  promptCard: {
+    maxWidth: 760,
+    margin: '0 auto 24px',
+    padding: 20,
+    borderRadius: 12,
+    border: '1px solid #f5efef',
+    boxShadow: '0 8px 24px rgba(255, 152, 0, 0.08)',
+    backgroundColor: '#fff',
   },
   promptField: {
     width: '100%',
+    '& .MuiOutlinedInput-root': {
+      borderRadius: 6,
+      backgroundColor: '#fff',
+      '&:hover .MuiOutlinedInput-notchedOutline': {
+        borderColor: SLING_ORANGE,
+      },
+      '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+        borderColor: SLING_ORANGE,
+        borderWidth: 2,
+      },
+    },
+  },
+  chips: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: 8,
+    marginTop: 12,
+    justifyContent: 'center',
+  },
+  chip: {
+    borderColor: '#ffd59a',
+    backgroundColor: SLING_CREAM,
+    color: '#7a4a00',
+    '&:hover': {
+      backgroundColor: '#ffe3b8',
+    },
   },
   actionBar: {
     display: 'flex',
     gap: 12,
     marginTop: 16,
     alignItems: 'center',
+    justifyContent: 'center',
+    flexWrap: 'wrap',
+  },
+  generateBtn: {
+    fontWeight: Fonts.MEDIUM,
+    textTransform: 'none',
+    backgroundColor: SLING_ORANGE,
+    color: '#fff',
+    borderRadius: 6,
+    padding: '10px 22px',
+    boxShadow: 'none',
+    '&:hover': {
+      backgroundColor: '#f57c00',
+      boxShadow: '0 4px 12px rgba(255, 152, 0, 0.28)',
+    },
+    '&:disabled': {
+      backgroundColor: '#ffd59a',
+      color: '#fff',
+    },
+  },
+  ghostBtn: {
+    fontWeight: Fonts.MEDIUM,
+    textTransform: 'none',
+    color: SLING_ORANGE,
+    borderColor: SLING_ORANGE,
+    borderRadius: 6,
   },
   resultSection: {
-    marginTop: 24,
+    marginTop: 8,
   },
   previewContainer: {
-    border: '1px solid rgba(0,0,0,0.12)',
+    border: '1px solid #f5efef',
     borderRadius: 8,
     overflow: 'hidden',
     minHeight: 400,
+    backgroundColor: '#fff',
   },
   metaCard: {
     padding: 16,
     marginBottom: 16,
+    borderRadius: 8,
+    border: '1px solid #f5efef',
   },
   metaRow: {
     display: 'flex',
     alignItems: 'center',
     marginBottom: 8,
     gap: 8,
+    flexWrap: 'wrap',
   },
-  btn: {
-    fontWeight: Fonts.MEDIUM,
-    textTransform: 'capitalize',
-  },
-  // Streaming code view
   codePane: {
-    backgroundColor: '#0d1117',
-    color: '#e6edf3',
+    backgroundColor: '#1a1a1a',
+    color: '#f5efef',
     fontFamily: "'JetBrains Mono', 'Fira Code', 'Cascadia Code', 'Consolas', monospace",
     fontSize: 13,
     lineHeight: 1.7,
@@ -80,7 +180,6 @@ const useStyles = makeStyles((theme) => ({
     maxHeight: 500,
     whiteSpace: 'pre-wrap',
     wordBreak: 'break-word',
-    position: 'relative',
   },
   '@keyframes blink': {
     '0%, 100%': {opacity: 1},
@@ -90,7 +189,7 @@ const useStyles = makeStyles((theme) => ({
     display: 'inline-block',
     width: 2,
     height: '1em',
-    backgroundColor: '#58a6ff',
+    backgroundColor: SLING_ORANGE,
     animation: '$blink 1s step-end infinite',
     verticalAlign: 'text-bottom',
     marginLeft: 1,
@@ -105,31 +204,33 @@ const useStyles = makeStyles((theme) => ({
     alignItems: 'center',
     justifyContent: 'center',
     minHeight: 400,
-    backgroundColor: '#f8f9fa',
+    backgroundColor: SLING_CREAM,
     borderRadius: 8,
-    border: '1px dashed rgba(0,0,0,0.15)',
+    border: `1px dashed ${SLING_ORANGE}`,
     gap: 12,
   },
   placeholderIcon: {
     fontSize: 48,
-    color: 'rgba(0,0,0,0.15)',
+    color: SLING_ORANGE,
+    opacity: 0.45,
     animation: '$pulse 2s ease-in-out infinite',
   },
   statusBar: {
     display: 'flex',
     alignItems: 'center',
     gap: 8,
-    marginBottom: 16,
+    margin: '0 auto 16px',
+    maxWidth: 760,
     padding: '8px 12px',
-    backgroundColor: '#f0f7ff',
+    backgroundColor: SLING_CREAM,
     borderRadius: 6,
-    border: '1px solid #d0e3f7',
+    border: '1px solid #ffd59a',
   },
   statusDot: {
     width: 8,
     height: 8,
     borderRadius: '50%',
-    backgroundColor: '#58a6ff',
+    backgroundColor: SLING_ORANGE,
     animation: '$pulse 1.5s ease-in-out infinite',
   },
   sectionLabel: {
@@ -140,10 +241,31 @@ const useStyles = makeStyles((theme) => ({
     color: theme.palette.text.secondary,
     marginBottom: 8,
   },
+  errorCard: {
+    maxWidth: 760,
+    margin: '0 auto 16px',
+    padding: 12,
+    borderColor: '#f44336',
+  },
+  headerIcon: {
+    color: SLING_ORANGE,
+  },
 }));
 
+function getAiBaseUrl() {
+  return (AI_SERVICE_URL || '').replace(/\/$/, '');
+}
+
+function getApiBaseUrl() {
+  return (SERVICE_URL || '').replace(/\/$/, '');
+}
+
 async function streamGenerate(prompt, themeConfig, callbacks) {
-  const baseUrl = (AI_SERVICE_URL || '').replace(/\/$/, '');
+  const baseUrl = getAiBaseUrl();
+  if (!baseUrl) {
+    throw new Error('AI_SERVICE_UNAVAILABLE');
+  }
+
   const res = await fetch(`${baseUrl}/widget/generate/stream`, {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
@@ -171,13 +293,27 @@ async function streamGenerate(prompt, themeConfig, callbacks) {
         try {
           const data = JSON.parse(line.slice(6));
           switch (data.type) {
-            case 'status': callbacks.onStatus?.(data.message); break;
-            case 'code_start': callbacks.onCodeStart?.(); break;
-            case 'code_token': callbacks.onCodeToken?.(data.text); break;
-            case 'complete': callbacks.onComplete?.(data.widget); break;
-            case 'error': callbacks.onError?.(data.message); break;
+            case 'status':
+              callbacks.onStatus?.(data.message);
+              break;
+            case 'code_start':
+              callbacks.onCodeStart?.();
+              break;
+            case 'code_token':
+              callbacks.onCodeToken?.(data.text);
+              break;
+            case 'complete':
+              callbacks.onComplete?.(data.widget);
+              break;
+            case 'error':
+              callbacks.onError?.(data.message);
+              break;
+            default:
+              break;
           }
-        } catch {}
+        } catch {
+          // ignore malformed SSE chunks
+        }
       }
     }
   }
@@ -189,7 +325,7 @@ const AiGenerateWidget = () => {
   const router = useRouter();
   const [prompt, setPrompt] = useState('');
   const [streaming, setStreaming] = useState(false);
-  const [phase, setPhase] = useState('idle'); // idle | thinking | coding | complete
+  const [phase, setPhase] = useState('idle');
   const [streamingCode, setStreamingCode] = useState('');
   const [statusMessage, setStatusMessage] = useState('');
   const [widget, setWidget] = useState(null);
@@ -204,6 +340,21 @@ const AiGenerateWidget = () => {
     }
   }, [streamingCode, phase]);
 
+  const persistWidget = async (widgetData) => {
+    setStatusMessage('Saving widget...');
+    setStreamingCode(widgetData.code || '');
+    const saved = await dispatch(saveGeneratedWidget(widgetData, prompt));
+    if (saved) {
+      setWidget(saved);
+      setPhase('complete');
+      setStatusMessage('');
+      return;
+    }
+    setError('Failed to save widget. Preview is still available.');
+    setWidget(widgetData);
+    setPhase('complete');
+  };
+
   const handleGenerate = async () => {
     if (!prompt.trim()) return;
     setStreaming(true);
@@ -216,7 +367,7 @@ const AiGenerateWidget = () => {
     setStatusMessage('AI is designing your widget...');
 
     try {
-      await streamGenerate(prompt.trim(), null, {
+      await streamGenerate(prompt.trim(), SLING_WIDGET_THEME, {
         onStatus: (msg) => setStatusMessage(msg),
         onCodeStart: () => {
           setPhase('coding');
@@ -226,18 +377,8 @@ const AiGenerateWidget = () => {
           setStreamingCode((prev) => prev + text);
         },
         onComplete: async (widgetData) => {
-          setStatusMessage('Saving widget...');
-          setStreamingCode(widgetData.code);
           try {
-            const saved = await dispatch(saveGeneratedWidget(widgetData, prompt));
-            if (saved) {
-              setWidget(saved);
-              setPhase('complete');
-              setStatusMessage('');
-            } else {
-              setError('Failed to save widget');
-              setPhase('complete');
-            }
+            await persistWidget(widgetData);
           } catch (saveErr) {
             setError(saveErr.message);
             setWidget(widgetData);
@@ -253,10 +394,40 @@ const AiGenerateWidget = () => {
         },
       });
     } catch (err) {
-      setError(err.message);
-      setStreaming(false);
-      setPhase('idle');
-      setStatusMessage('');
+      try {
+        setStatusMessage('Generating without stream...');
+        const apiBase = getApiBaseUrl();
+        if (apiBase) {
+          const client = await ApiAuth();
+          const res = await client.post(`${apiBase}/v1/widgets/generate`, {
+            prompt: prompt.trim(),
+            themeConfig: SLING_WIDGET_THEME,
+          });
+          if (res?.data?.widget) {
+            setWidget(res.data.widget);
+            setStreamingCode(res.data.widget.code || '');
+            setPhase('complete');
+            setStreaming(false);
+            setStatusMessage('');
+            return;
+          }
+        }
+        const saved = await dispatch(generateWidget(prompt.trim(), SLING_WIDGET_THEME));
+        if (saved) {
+          setWidget(saved);
+          setStreamingCode(saved.code || '');
+          setPhase('complete');
+          setStreaming(false);
+          setStatusMessage('');
+          return;
+        }
+        throw err;
+      } catch (fallbackErr) {
+        setError(fallbackErr.message || err.message);
+        setStreaming(false);
+        setPhase('idle');
+        setStatusMessage('');
+      }
     }
   };
 
@@ -276,36 +447,56 @@ const AiGenerateWidget = () => {
     <Box className={classes.root}>
       <AppsHeader>
         <Box fontWeight={Fonts.BOLD} component='h3' style={{display: 'flex', alignItems: 'center', gap: 8}}>
-          <Icon>auto_awesome</Icon>
+          <Icon className={classes.headerIcon}>auto_awesome</Icon>
           AI Widget Generator
         </Box>
-        <Button className={classes.btn} variant='text' color='primary' onClick={() => router.push('/widgets/widgets-integration')}>
+        <Button className={classes.ghostBtn} variant='outlined' onClick={() => router.push('/widgets/widgets-integration')}>
           Back to Widgets
         </Button>
       </AppsHeader>
 
       <Box className={classes.content}>
-        {/* Prompt */}
-        <Box className={classes.promptSection}>
-          <Typography variant='body1' gutterBottom>
-            Describe the widget you want to generate:
+        <Box className={classes.hero}>
+          <Typography className={classes.eyebrow}>
+            <Icon style={{fontSize: 16}}>auto_awesome</Icon>
+            Governed AI
           </Typography>
+          <Typography className={classes.title}>
+            Describe a widget. Sling generates a tenant-private component.
+          </Typography>
+          <Typography className={classes.subtitle}>
+            Generated code stays in your workspace, goes through review, and never leaks to another client.
+          </Typography>
+        </Box>
+
+        <Paper className={classes.promptCard} elevation={0}>
           <TextField
             className={classes.promptField}
             multiline
             rows={3}
             variant='outlined'
-            placeholder='e.g. A pricing table with three tiers showing features and pricing'
+            placeholder='e.g. A login form with email, password, and a Remember me checkbox'
             value={prompt}
             onChange={(e) => setPrompt(e.target.value)}
             onKeyDown={handleKeyDown}
             disabled={streaming}
           />
+          <Box className={classes.chips}>
+            {STARTER_PROMPTS.map((idea) => (
+              <Chip
+                key={idea}
+                className={classes.chip}
+                size='small'
+                label={idea}
+                onClick={() => setPrompt(idea)}
+                disabled={streaming}
+              />
+            ))}
+          </Box>
           <Box className={classes.actionBar}>
             <Button
-              className={classes.btn}
+              className={classes.generateBtn}
               variant='contained'
-              color='primary'
               onClick={handleGenerate}
               disabled={streaming || !prompt.trim()}
               startIcon={<Icon>auto_awesome</Icon>}>
@@ -313,25 +504,24 @@ const AiGenerateWidget = () => {
             </Button>
             {widget && !streaming && (
               <Button
-                className={classes.btn}
+                className={classes.ghostBtn}
                 variant='outlined'
-                color='primary'
                 onClick={handleGenerate}
                 startIcon={<Icon>refresh</Icon>}>
                 Regenerate
               </Button>
             )}
           </Box>
-        </Box>
+        </Paper>
 
-        {/* Error */}
         {error && (
-          <Paper variant='outlined' style={{padding: 12, marginBottom: 16, borderColor: '#f44336'}}>
-            <Typography variant='body2' color='error'>{error}</Typography>
+          <Paper variant='outlined' className={classes.errorCard}>
+            <Typography variant='body2' color='error'>
+              {error}
+            </Typography>
           </Paper>
         )}
 
-        {/* Status bar during streaming */}
         {isWorking && (
           <Box className={classes.statusBar}>
             <Box className={classes.statusDot} />
@@ -341,10 +531,8 @@ const AiGenerateWidget = () => {
           </Box>
         )}
 
-        {/* Streaming / Result area */}
         {(isWorking || phase === 'complete') && (
           <Box className={classes.resultSection}>
-            {/* Metadata card - only when complete */}
             {phase === 'complete' && widget && (
               <Paper className={classes.metaCard} variant='outlined'>
                 <Box className={classes.metaRow}>
@@ -363,12 +551,25 @@ const AiGenerateWidget = () => {
                 )}
                 <Box className={classes.metaRow}>
                   <Typography variant='subtitle2'>Status:</Typography>
-                  <Chip size='small' label={submitted ? 'pending review' : (widget.status || 'draft').replace('_', ' ')} color={submitted ? 'primary' : 'default'} variant='outlined' />
-                  <Chip size='small' label='AI' color='primary' style={{height: 20, fontSize: 10}} />
+                  <Chip
+                    size='small'
+                    label={submitted ? 'pending review' : (widget.status || 'draft').replace('_', ' ')}
+                    variant='outlined'
+                  />
+                  <Chip
+                    size='small'
+                    label='AI'
+                    style={{height: 20, fontSize: 10, backgroundColor: SLING_ORANGE, color: '#fff'}}
+                  />
                 </Box>
                 {widget._id && (
                   <Box style={{marginTop: 12}}>
-                    <Button className={classes.btn} variant='contained' color='primary' onClick={handleSubmitForReview} disabled={submitted} startIcon={<Icon>rate_review</Icon>}>
+                    <Button
+                      className={classes.generateBtn}
+                      variant='contained'
+                      onClick={handleSubmitForReview}
+                      disabled={submitted}
+                      startIcon={<Icon>rate_review</Icon>}>
                       {submitted ? 'Submitted for Review' : 'Submit for Review'}
                     </Button>
                   </Box>
@@ -377,7 +578,6 @@ const AiGenerateWidget = () => {
             )}
 
             <Grid container spacing={3}>
-              {/* Preview */}
               <Grid item xs={12} md={6}>
                 <Typography className={classes.sectionLabel}>Preview</Typography>
                 {phase === 'complete' && widget ? (
@@ -385,7 +585,8 @@ const AiGenerateWidget = () => {
                     <SandboxedPreview
                       code={widget.code || streamingCode}
                       dependencies={widget.dependencies}
-                      style={{minHeight: 400}}
+                      themeOverrides={SLING_WIDGET_THEME}
+                      style={{minHeight: 400, background: '#fff'}}
                       onError={setPreviewError}
                     />
                   </Box>
@@ -404,14 +605,13 @@ const AiGenerateWidget = () => {
                 )}
               </Grid>
 
-              {/* Code */}
               <Grid item xs={12} md={6}>
                 <Typography className={classes.sectionLabel}>
                   {phase === 'coding' ? 'Writing Code...' : 'Generated Code'}
                 </Typography>
                 <Box className={classes.codePane} ref={codeRef}>
                   {phase === 'thinking' && !streamingCode ? (
-                    <Typography variant='body2' style={{color: '#8b949e', fontStyle: 'italic'}}>
+                    <Typography variant='body2' style={{color: '#c4c4c4', fontStyle: 'italic'}}>
                       Waiting for AI response...
                     </Typography>
                   ) : (

--- a/modules/widgetsModule/WidgetsDetail/WidgetsIntegration/index.js
+++ b/modules/widgetsModule/WidgetsDetail/WidgetsIntegration/index.js
@@ -253,9 +253,9 @@ const WidgetsIntegration = (props) => {
           <Tooltip title='Generate with AI'>
             <IconButton onClick={() => router.push('/widgets/ai-generate')}>
               <Icon
-                color='primary'
                 className={classes.iconDefault}
-                aria-label={'Generate with AI'}>
+                aria-label={'Generate with AI'}
+                style={{color: '#ff9800'}}>
                 auto_awesome
               </Icon>
             </IconButton>

--- a/pages/sandbox/widget-preview.js
+++ b/pages/sandbox/widget-preview.js
@@ -78,14 +78,17 @@ export default function WidgetPreviewSandbox() {
         });
 
         const {code: transpiled} = Babel.transform(code, {presets: ['react']});
-
-        const scopeKeys = Object.keys(scope);
-        const scopeValues = scopeKeys.map((key) => scope[key]);
+        const {ThemedComponent, ...factoryScope} = scope;
+        const scopeKeys = Object.keys(factoryScope);
+        const scopeValues = scopeKeys.map((key) => factoryScope[key]);
 
         // eslint-disable-next-line no-new-func
         const factory = new Function(
           ...scopeKeys,
-          `${transpiled}\nreturn typeof PreviewComponent !== 'undefined' ? PreviewComponent : null;`,
+          `${transpiled}
+            if (typeof PreviewComponent === 'function') return PreviewComponent;
+            if (typeof Component === 'function') return Component;
+            return null;`,
         );
 
         const Component = factory(...scopeValues);
@@ -96,7 +99,13 @@ export default function WidgetPreviewSandbox() {
         if (!rootRef.current && mountRef.current) {
           rootRef.current = createRoot(mountRef.current);
         }
-        rootRef.current.render(React.createElement(Component));
+        rootRef.current.render(
+          React.createElement(
+            ThemedComponent,
+            null,
+            React.createElement(Component),
+          ),
+        );
 
         postToParent('RENDER_SUCCESS', {
           nonce: nonceRef.current,
@@ -141,7 +150,11 @@ export default function WidgetPreviewSandbox() {
         <meta httpEquiv="Content-Security-Policy" content={CSP} />
         <title>Sling widget preview</title>
       </Head>
-      <div id="sling-sandbox-root" ref={mountRef} />
+      <div
+        id="sling-sandbox-root"
+        ref={mountRef}
+        style={{minHeight: '100vh', background: '#fff', padding: 16, boxSizing: 'border-box'}}
+      />
     </>
   );
 }

--- a/redux/actions/Widgets.js
+++ b/redux/actions/Widgets.js
@@ -139,7 +139,8 @@ export const generateWidget = (prompt, themeConfig) => {
   return async (dispatch) => {
     dispatch({type: GENERATE_WIDGET_START});
     try {
-      const aiRes = await fetch(`${AI_SERVICE_URL}widget/generate`, {
+      const aiBase = (AI_SERVICE_URL || '').replace(/\/$/, '');
+      const aiRes = await fetch(`${aiBase}/widget/generate`, {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({prompt, themeConfig}),


### PR DESCRIPTION
## Summary
- Match the generator UI and sandbox theme to sling.biz orange (`#ff9800`)
- Always inject common MUI form components so login previews are not blank
- Pass brand theme into generation and preview

## Test plan
- [ ] Open Widgets → AI Generate on studio.sling.biz
- [ ] Confirm orange generate button / cream hero / starter chips
- [ ] Generate "login form with email, password, and remember-me"
- [ ] Confirm preview is not a blank white box
- [ ] Click Regenerate and confirm it does not fail with Widget Key already taken


Made with [Cursor](https://cursor.com)