### PR TITLE
Role-based Publish vs Submit for Review

### DIFF
--- a/@sling/utility/AppHooks.js
+++ b/@sling/utility/AppHooks.js
@@ -34,6 +34,10 @@ export const useAuthToken = () => {
       dispatch(setJWTToken(token));
       try {
         const res = await jwtAxios.get('/auth');
+        const storedUser =
+          typeof window !== 'undefined'
+            ? JSON.parse(localStorage.getItem('user') || 'null')
+            : null;
         dispatch(fetchSuccess());
         setLoading(false);
         dispatch({
@@ -42,7 +46,7 @@ export const useAuthToken = () => {
             authType: AuthType.JWT_AUTH,
             displayName: res.data.name,
             email: res.data.email,
-            role: defaultUser.role,
+            role: res.data.role || storedUser?.role || defaultUser.role,
             token: res.data._id,
             photoURL: res.data.avatar,
           },

--- a/@sling/utility/AppHooks.role.test.js
+++ b/@sling/utility/AppHooks.role.test.js
@@ -1,0 +1,11 @@
+const fs = require('fs');
+const path = require('path');
+
+const src = fs.readFileSync(path.join(__dirname, 'AppHooks.js'), 'utf8');
+
+describe('AppHooks JWT role', () => {
+  test('uses the role from /auth instead of forcing the default user role', () => {
+    expect(src).toMatch(/res\.data\.role \|\| storedUser\?\.role \|\| defaultUser\.role/);
+    expect(src).not.toMatch(/role:\s*defaultUser\.role,/);
+  });
+});

--- a/modules/widgetsModule/AiGenerateWidget/AiGenerateWidget.layout.test.js
+++ b/modules/widgetsModule/AiGenerateWidget/AiGenerateWidget.layout.test.js
@@ -29,4 +29,12 @@ describe('AiGenerateWidget layout', () => {
     expect(src).toMatch(/widget\?._id \|\| widget\?\.id/);
     expect(src).toMatch(/Submit for Review/);
   });
+
+  test('admins and publishers get Publish; everyone else submits for review', () => {
+    expect(src).toMatch(/publishWidgetAction/);
+    expect(src).toMatch(/role === 'admin'/);
+    expect(src).toMatch(/role === 'publisher'/);
+    expect(src).toMatch(/'Publish'/);
+    expect(src).toMatch(/Saved as draft/);
+  });
 });

--- a/modules/widgetsModule/AiGenerateWidget/index.js
+++ b/modules/widgetsModule/AiGenerateWidget/index.js
@@ -17,7 +17,9 @@ import {
   generateWidget,
   saveGeneratedWidget,
   submitForReview,
+  publishWidgetAction,
 } from '../../../redux/actions/Widgets';
+import {useAuthUser} from '../../../@sling/utility/AppHooks';
 import SandboxedPreview from '../../aiBuilder/components/SandboxedPreview';
 import {useRouter} from 'next/router';
 import {AI_SERVICE_URL, SERVICE_URL} from '../../../shared/constants/Services';
@@ -352,6 +354,8 @@ const AiGenerateWidget = () => {
   const dispatch = useDispatch();
   const router = useRouter();
   const {theme} = useContext(AppContext);
+  const user = useAuthUser();
+  const canPublish = user?.role === 'admin' || user?.role === 'publisher';
   const tenantTheme = resolveWidgetTheme(theme);
   const [prompt, setPrompt] = useState('');
   const [streaming, setStreaming] = useState(false);
@@ -361,6 +365,7 @@ const AiGenerateWidget = () => {
   const [widget, setWidget] = useState(null);
   const [previewError, setPreviewError] = useState(null);
   const [submitted, setSubmitted] = useState(false);
+  const [published, setPublished] = useState(false);
   const [error, setError] = useState(null);
   const [promptOpen, setPromptOpen] = useState(true);
   const codeRef = useRef(null);
@@ -396,6 +401,7 @@ const AiGenerateWidget = () => {
     setStreamingCode('');
     setWidget(null);
     setSubmitted(false);
+    setPublished(false);
     setPreviewError(null);
     setError(null);
     setStatusMessage('AI is designing your widget...');
@@ -475,6 +481,48 @@ const AiGenerateWidget = () => {
     const result = await dispatch(submitForReview(widgetId));
     if (result) setSubmitted(true);
   };
+
+  const handlePublish = async () => {
+    if (!widgetId) return;
+    const result = await dispatch(publishWidgetAction(widgetId));
+    if (result) {
+      setWidget(result);
+      setPublished(true);
+    }
+  };
+
+  const statusLabel = published
+    ? 'published'
+    : submitted
+    ? 'pending review'
+    : (widget?.status || 'draft').replace('_', ' ');
+
+  const renderGovernanceActions = () => (
+    <Box className={classes.actionBar} style={{justifyContent: 'flex-start'}}>
+      <Typography variant='body2' color='textSecondary'>
+        {published ? 'Published' : submitted ? 'In review' : 'Saved as draft'}
+      </Typography>
+      {canPublish ? (
+        <Button
+          className={classes.generateBtn}
+          variant='contained'
+          onClick={handlePublish}
+          disabled={published || !widgetId}
+          startIcon={<Icon>publish</Icon>}>
+          {published ? 'Published' : 'Publish'}
+        </Button>
+      ) : (
+        <Button
+          className={classes.generateBtn}
+          variant='contained'
+          onClick={handleSubmitForReview}
+          disabled={submitted || published || !widgetId}
+          startIcon={<Icon>rate_review</Icon>}>
+          {submitted ? 'Submitted for Review' : 'Submit for Review'}
+        </Button>
+      )}
+    </Box>
+  );
 
   const handleKeyDown = (e) => {
     if (e.key === 'Enter' && !e.shiftKey) {
@@ -617,7 +665,7 @@ const AiGenerateWidget = () => {
                   />
                   <Chip
                     size='small'
-                    label={submitted ? 'pending review' : (widget.status || 'draft').replace('_', ' ')}
+                    label={statusLabel}
                     variant='outlined'
                   />
                   <Chip
@@ -629,16 +677,7 @@ const AiGenerateWidget = () => {
                     <Chip className={classes.metaChip} size='small' label={widget.description} variant='outlined' />
                   )}
                 </Box>
-                <Box style={{marginTop: 12}}>
-                  <Button
-                    className={classes.generateBtn}
-                    variant='contained'
-                    onClick={handleSubmitForReview}
-                    disabled={submitted || !widgetId}
-                    startIcon={<Icon>rate_review</Icon>}>
-                    {submitted ? 'Submitted for Review' : 'Submit for Review'}
-                  </Button>
-                </Box>
+                {renderGovernanceActions()}
               </Paper>
             )}
 
@@ -690,6 +729,7 @@ const AiGenerateWidget = () => {
                 </Box>
               </Grid>
             </Grid>
+            {phase === 'complete' && widget && renderGovernanceActions()}
           </Box>
         )}
       </Box>

--- a/modules/widgetsModule/WidgetsDetail/WidgetsIntegration/WidgetsIntegration.preview.test.js
+++ b/modules/widgetsModule/WidgetsDetail/WidgetsIntegration/WidgetsIntegration.preview.test.js
@@ -36,4 +36,10 @@ describe('WidgetsIntegration live preview', () => {
     expect(src).not.toMatch(/type:\s*'widget'/);
     expect(src).not.toMatch(/getWidgetType/);
   });
+
+  test('does not dump removable status - published chips next to the yellow filter', () => {
+    expect(src).not.toMatch(/status - \$\{/);
+    expect(src).not.toMatch(/onDelete=\{\(\) => handleDeleteFilter/);
+    expect(src).not.toMatch(/Object\.keys\(filter\)/);
+  });
 });

--- a/modules/widgetsModule/WidgetsDetail/WidgetsIntegration/index.js
+++ b/modules/widgetsModule/WidgetsDetail/WidgetsIntegration/index.js
@@ -260,14 +260,6 @@ const WidgetsIntegration = (props) => {
     }
   };
 
-  const handleDeleteFilter = (key) => {
-    delete filter[key];
-    if (key === 'query') {
-      setQuery('');
-    }
-    setFilter({...filter});
-  };
-
   const handleDeleteWidget = () => {
     if (widgetToDelete) {
       dispatch(deleteWidget(widgetToDelete));
@@ -297,24 +289,6 @@ const WidgetsIntegration = (props) => {
           Widgets
         </Box>
         <Box style={{display: 'flex', alignItems: 'center'}}>
-          <Box>
-            {Object.keys(filter).map((v, key) => {
-              return filter[v] && v != 'type' ? (
-                <Chip
-                  key={key}
-                  size={'small'}
-                  label={`${v} - ${filter[v]}`}
-                  aria-label={`Remove ${v}`}
-                  color='primary'
-                  variant='outlined'
-                  onClick={() => handleDeleteFilter(v)}
-                  onDelete={() => handleDeleteFilter(v)}
-                />
-              ) : (
-                ''
-              );
-            })}
-          </Box>
           <Box className={classes.statusFilters}>
             {STATUS_FILTERS.map((option) => (
               <Chip

--- a/modules/widgetsModule/WidgetsSideBar/WidgetsSideBar.test.js
+++ b/modules/widgetsModule/WidgetsSideBar/WidgetsSideBar.test.js
@@ -10,4 +10,12 @@ describe('Widgets sidebar folderList', () => {
     expect(src).not.toMatch(/name:\s*'Blocks'/);
     expect(src).not.toMatch(/name:\s*'Components'/);
   });
+
+  test('hides Review Queue unless the signed-in user can publish', () => {
+    expect(src).toMatch(/name:\s*'Review Queue'/);
+    expect(src).toMatch(/adminOnly:\s*true/);
+    expect(src).toMatch(/visibleFolders/);
+    expect(src).toMatch(/role === 'admin'/);
+    expect(src).toMatch(/role === 'publisher'/);
+  });
 });

--- a/modules/widgetsModule/WidgetsSideBar/index.js
+++ b/modules/widgetsModule/WidgetsSideBar/index.js
@@ -8,13 +8,14 @@ import AppList from '../../../@sling/core/AppList';
 import ListEmptyResult from '../../../@sling/core/AppList/ListEmptyResult';
 import SidebarPlaceholder from '../../../@sling/core/Skeleton/SidebarListSkeleton';
 import AppsSideBarFolderItemCustom from '../../../@sling/core/AppsSideBarFolderItem/custom';
+import {useAuthUser} from '../../../@sling/utility/AppHooks';
 
 export const folderList = [
   {id: 1, name: 'Widgets', alias: 'widgets-integration', icon: 'widgets'},
   {id: 5, name: 'Market Place', alias: 'market-place', icon: 'store_front'},
   {id: 5, name: 'Guide', alias: 'guide', icon: 'help_center'},
   {id: 6, name: 'AI Generate', alias: 'ai-generate', icon: 'auto_awesome'},
-  {id: 7, name: 'Review Queue', alias: 'review-queue', icon: 'rate_review'},
+  {id: 7, name: 'Review Queue', alias: 'review-queue', icon: 'rate_review', adminOnly: true},
 ];
 
 const useStyle = makeStyles((theme) => ({
@@ -43,6 +44,9 @@ const useStyle = makeStyles((theme) => ({
 
 const RoutesSideBar = ({basePath, noSubChild}) => {
   const classes = useStyle();
+  const user = useAuthUser();
+  const canReview = user?.role === 'admin' || user?.role === 'publisher';
+  const visibleFolders = folderList.filter((item) => !item.adminOnly || canReview);
 
   return (
     <>
@@ -55,7 +59,7 @@ const RoutesSideBar = ({basePath, noSubChild}) => {
               className={classes.listRoot}>
               <AppList
                 pageClasses={classes}
-                data={folderList}
+                data={visibleFolders}
                 ListEmptyComponent={
                   <ListEmptyResult
                     loading={true}


### PR DESCRIPTION
## Summary
- Drop the extra removable filter chip; the yellow Published/Draft chips are the selection.
- Hide Review Queue unless the user is an admin or publisher.
- On generate, regular users submit for review; admins and publishers get Publish. Draft is already auto-saved.

## Test plan
- [ ] Open Widgets: only yellow Published/Draft chips, no blue status - published X chip
- [ ] Regular user: no Review Queue, generate screen shows Submit for Review
- [ ] Admin/publisher: Review Queue visible, generate screen shows Publish
- [ ] Publish from a saved draft succeeds for admin

Made with [Cursor](https://cursor.com)