### PR TITLE
Fix Members page so Vercel can build Studio

### DIFF
--- a/modules/settingsModule/SettingsDetail/Members/index.js
+++ b/modules/settingsModule/SettingsDetail/Members/index.js
@@ -9,7 +9,7 @@ import {
   Icon,
 } from '@material-ui/core';
 import {makeStyles} from '@material-ui/core/styles';
-import AppsHeader from '../../../../@sling/core/AppsHeader';
+import AppsHeader from '../../../../@sling/core/AppsContainer/AppsHeader';
 import {Fonts} from '../../../../shared/constants/AppEnums';
 import ApiAuth from '../../../../@sling/services/ApiAuthConfig';
 import {SERVICE_URL} from '../../../../shared/constants/Services';


### PR DESCRIPTION
## Summary
- Settings → Members imported a header file that does not exist, so Vercel failed in ~11s on both preview and production.
- Pointed the import at the same header path the other Settings pages already use.
- Local `next build` now compiles, including `/settings` and `/invite/[token]`.

## Test plan
- [ ] Vercel production deploy for this commit turns green
- [ ] studio.sling.biz loads
- [ ] Settings → Members still opens for owners/admins


Made with [Cursor](https://cursor.com)